### PR TITLE
add aria-label to icon component

### DIFF
--- a/src/components/button/__stories__/button.stories.ts
+++ b/src/components/button/__stories__/button.stories.ts
@@ -20,20 +20,25 @@ export default {
   parameters: {},
   argTypes: {
     label: {
+      description: 'Button text',
       control: { type: 'text' },
     },
     href: {
+      description: 'Link URL',
       control: { type: 'text' },
     },
     target: {
+      description: 'Where to open the link (value of the target attribute)',
       options: [...optionsLinkTargets],
       control: { type: 'select' },
     },
     type: {
+      description: 'Button type',
       options: [...optionsType],
       control: { type: 'select' },
     },
     size: {
+      description: 'Button size',
       options: [
         null,
         ...optionsSize,
@@ -46,6 +51,7 @@ export default {
       },
     },
     icon: {
+      description: 'Icon to display in the button',
       options: [
         null,
         ...optionsIcon,
@@ -57,7 +63,12 @@ export default {
         },
       },
     },
+    iconAriaLabel: {
+      description: 'Accessible aria label on the icon (used for icon only button)',
+      control: { type: 'text' },
+    },
     iconPosition: {
+      description: 'Icon position relative to text label (center for icon only button)',
       options: [
         ...optionsIconPosition,
       ],
@@ -66,6 +77,7 @@ export default {
       },
     },
     theme: {
+      description: 'Color theme',
       options: [
         null,
         ...optionsTheme,
@@ -87,6 +99,7 @@ const Template = args => {
       size=${args.size}
       icon=${args.icon}
       iconPosition=${args.iconPosition}
+      iconAriaLabel=${args.iconAriaLabel}
       href=${args.href}
       target=${args.target}
       theme=${args.theme}

--- a/src/components/button/__stories__/button.stories.ts
+++ b/src/components/button/__stories__/button.stories.ts
@@ -19,8 +19,8 @@ export default {
   component: `${PREFIX_TAG}-button`,
   parameters: {},
   argTypes: {
-    label: {
-      description: 'Button text',
+    ariaLabel: {
+      description: 'Accessible aria label provides discernible text for icon only buttons or additional context.',
       control: { type: 'text' },
     },
     href: {
@@ -63,10 +63,6 @@ export default {
         },
       },
     },
-    iconAriaLabel: {
-      description: 'Accessible aria label on the icon (used for icon only button)',
-      control: { type: 'text' },
-    },
     iconPosition: {
       description: 'Icon position relative to text label (center for icon only button)',
       options: [
@@ -99,17 +95,16 @@ const Template = args => {
       size=${args.size}
       icon=${args.icon}
       iconPosition=${args.iconPosition}
-      iconAriaLabel=${args.iconAriaLabel}
+      ariaLabel=${args.ariaLabel}
       href=${args.href}
       target=${args.target}
       theme=${args.theme}
-    >${args.label}</kd-button>
+    >Button Text</kd-button>
   `;
 };
 
 export const Button = Template.bind({});
 Button.args = {
-  label: 'Click here',
   href: 'http://kyndryl.com',
   target: LINK_TARGETS.SELF,
   type: BUTTON_TYPES.PRIMARY,

--- a/src/components/button/__stories__/button.stories.ts
+++ b/src/components/button/__stories__/button.stories.ts
@@ -19,8 +19,8 @@ export default {
   component: `${PREFIX_TAG}-button`,
   parameters: {},
   argTypes: {
-    ariaLabel: {
-      description: 'Accessible aria label provides discernible text for icon only buttons or additional context.',
+    description: {
+      description: 'Accessible aria label that provides discernible text for icon only buttons or additional context',
       control: { type: 'text' },
     },
     href: {
@@ -95,7 +95,7 @@ const Template = args => {
       size=${args.size}
       icon=${args.icon}
       iconPosition=${args.iconPosition}
-      ariaLabel=${args.ariaLabel}
+      description=${args.description}
       href=${args.href}
       target=${args.target}
       theme=${args.theme}

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -20,7 +20,7 @@ import stylesheet from './button.scss';
 export class Button extends LitElement {
   static styles = [stylesheet];
 
-  @property({ type: String }) ariaLabel;
+  @property({ type: String }) description;
   @property({ type: String }) href;
   @property() target: LINK_TARGETS;
   @property() type: BUTTON_TYPES;
@@ -40,11 +40,11 @@ export class Button extends LitElement {
       [`${PREFIX_CLASS_THEME}-${this.theme}`]: this.theme,
     });
     if (!this.icon) {
-      return html`<a id="button" href=${this.href} target=${this.target} class=${classes} aria-label=${ifDefined(this.ariaLabel ? this.ariaLabel : undefined)}>
+      return html`<a id="button" href=${this.href} target=${this.target} class=${classes} aria-label=${ifDefined(this.description ? this.description : undefined)}>
         <slot></slot>
       </a>`;
     } else {
-      return html`<a id="button" href=${this.href} target=${this.target} class=${classes} aria-label=${ifDefined(this.ariaLabel ? this.ariaLabel : undefined)}>
+      return html`<a id="button" href=${this.href} target=${this.target} class=${classes} aria-label=${ifDefined(this.description ? this.description : undefined)}>
         <slot></slot>
         <span class="${PREFIX_CLASS}-btn--icon">
           <kd-icon icon=${this.icon}></kd-icon>

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -1,5 +1,6 @@
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { PREFIX_CLASS, PREFIX_CLASS_THEME, PREFIX_TAG } from '../../global/settings/settings';
 import { ICON_IDS } from '../../global/defs/iconIds';
@@ -19,13 +20,13 @@ import stylesheet from './button.scss';
 export class Button extends LitElement {
   static styles = [stylesheet];
 
+  @property({ type: String }) ariaLabel;
   @property({ type: String }) href;
   @property() target: LINK_TARGETS;
   @property() type: BUTTON_TYPES;
   @property() size: BUTTON_SIZES;
   @property() icon: ICON_IDS;
   @property() iconPosition: BUTTON_ICON_POSITION;
-  @property({ type: String }) iconAriaLabel;
   @property() theme: THEMES;
 
   render() {
@@ -39,14 +40,14 @@ export class Button extends LitElement {
       [`${PREFIX_CLASS_THEME}-${this.theme}`]: this.theme,
     });
     if (!this.icon) {
-      return html`<a id="button" href=${this.href} target=${this.target} class=${classes}>
+      return html`<a id="button" href=${this.href} target=${this.target} class=${classes} aria-label=${ifDefined(this.ariaLabel ? this.ariaLabel : undefined)}>
         <slot></slot>
       </a>`;
     } else {
-      return html`<a id="button" href=${this.href} target=${this.target} class=${classes}>
+      return html`<a id="button" href=${this.href} target=${this.target} class=${classes} aria-label=${ifDefined(this.ariaLabel ? this.ariaLabel : undefined)}>
         <slot></slot>
         <span class="${PREFIX_CLASS}-btn--icon">
-          <kd-icon icon=${this.icon} ariaLabel=${this.iconAriaLabel}></kd-icon>
+          <kd-icon icon=${this.icon}></kd-icon>
         </span>
       </a>`;
     }

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -25,6 +25,7 @@ export class Button extends LitElement {
   @property() size: BUTTON_SIZES;
   @property() icon: ICON_IDS;
   @property() iconPosition: BUTTON_ICON_POSITION;
+  @property({ type: String }) iconAriaLabel;
   @property() theme: THEMES;
 
   render() {
@@ -45,7 +46,7 @@ export class Button extends LitElement {
       return html`<a id="button" href=${this.href} target=${this.target} class=${classes}>
         <slot></slot>
         <span class="${PREFIX_CLASS}-btn--icon">
-          <kd-icon icon=${this.icon}></kd-icon>
+          <kd-icon icon=${this.icon} ariaLabel=${this.iconAriaLabel}></kd-icon>
         </span>
       </a>`;
     }

--- a/src/components/icon/__stories__/icon.stories.ts
+++ b/src/components/icon/__stories__/icon.stories.ts
@@ -11,6 +11,7 @@ export default {
   component: `${PREFIX_TAG}-icon`,
   argTypes: {
     icon: {
+      description: 'Icon ID',
       options: [
         null,
         ...optionsIcon,
@@ -21,13 +22,17 @@ export default {
           null: 'none',
         },
       },
-    }
-  }
+    },
+    ariaLabel: {
+      description: 'Accessible aria label for the icon (fallback value is the Icon ID)',
+      control: { type: 'text' },
+    },
+  },
 };
 
 const Template = args => {
   return html`
-    <kd-icon icon=${args.icon}></kd-icon>
+    <kd-icon icon=${args.icon} ariaLabel=${args.ariaLabel}></kd-icon>
   `;
 };
 
@@ -63,4 +68,5 @@ export const Icons = () => {
 export const SingleIcon = Template.bind({});
 SingleIcon.args = {
   icon: ICON_IDS.ARROW_RIGHT,
+  ariaLabel: 'arrow right icon'
 };

--- a/src/components/icon/__stories__/icon.stories.ts
+++ b/src/components/icon/__stories__/icon.stories.ts
@@ -23,16 +23,12 @@ export default {
         },
       },
     },
-    ariaLabel: {
-      description: 'Accessible aria label for the icon (fallback value is the Icon ID)',
-      control: { type: 'text' },
-    },
   },
 };
 
 const Template = args => {
   return html`
-    <kd-icon icon=${args.icon} ariaLabel=${args.ariaLabel}></kd-icon>
+    <kd-icon icon=${args.icon}></kd-icon>
   `;
 };
 
@@ -68,5 +64,4 @@ export const Icons = () => {
 export const SingleIcon = Template.bind({});
 SingleIcon.args = {
   icon: ICON_IDS.ARROW_RIGHT,
-  ariaLabel: 'arrow right icon'
 };

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -10,7 +10,6 @@ export class Icon extends LitElement {
   static styles = [stylesheet];
 
   @property() icon: ICON_IDS;
-  @property({ type: String }) ariaLabel;
 
   render() {
     const icon_classes = classMap({
@@ -19,7 +18,7 @@ export class Icon extends LitElement {
     });
 
     if (this.icon) {
-      return html`<span role="img" aria-label=${this.ariaLabel ? this.ariaLabel : this.icon} class=${icon_classes}></span>`;
+      return html`<span role="img" aria-hidden="true" class=${icon_classes}></span>`;
     }
 
     return null;

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -10,6 +10,7 @@ export class Icon extends LitElement {
   static styles = [stylesheet];
 
   @property() icon: ICON_IDS;
+  @property({ type: String }) ariaLabel;
 
   render() {
     const icon_classes = classMap({
@@ -18,7 +19,7 @@ export class Icon extends LitElement {
     });
 
     if (this.icon) {
-      return html`<span class=${icon_classes}></span>`;
+      return html`<span role="img" aria-label=${this.ariaLabel ? this.ariaLabel : this.icon} class=${icon_classes}></span>`;
     }
 
     return null;

--- a/src/components/videoPlayer/__stories__/videoPlayer.stories.ts
+++ b/src/components/videoPlayer/__stories__/videoPlayer.stories.ts
@@ -32,9 +32,17 @@ export default {
       description: 'URL of poster image',
       control: { type: 'text' },
     },
-    buttonLabel: {
-      description: 'Text to display in the play/pause button',
+    buttonLabelPlay: {
+      description: 'Text to display in the play button',
       control: { type: 'text' },
+    },
+    buttonLabelPause: {
+      description: 'Text to display in the pause button',
+      control: { type: 'text' },
+    },
+    showButtonLabel: {
+      description: 'Show play/pause label or use them for accessible aria label on the icon',
+      control: { type: 'boolean' },
     },
     buttonSize: {
       description: 'Size of the play/pause button',
@@ -77,6 +85,7 @@ export default {
       },
     },
     buttonIconPosition: {
+      description: 'Icon position relative to button label (center for icon only button)',
       options: [
         ...optionsButtonIconPosition,
       ],
@@ -116,7 +125,9 @@ const Template = args => {
       youtubeId=${args.youtubeId}
       title=${args.title}
       poster=${args.poster}
-      buttonLabel=${args.buttonLabel}
+      buttonLabelPlay=${args.buttonLabelPlay}
+      buttonLabelPause=${args.buttonLabelPause}
+      showButtonLabel=${args.showButtonLabel}
       buttonSize=${args.buttonSize}
       buttonIconPlay=${args.buttonIconPlay}
       buttonIconPause=${args.buttonIconPause}
@@ -131,7 +142,8 @@ export const Default = Template.bind({});
 Default.args = {
   video: 'https://s7d1.scene7.com/is/content/kyndryl/5.%20MS-Launch-Social-1080.captions',
   title: 'Video Title',
-  buttonLabel: 'Play',
+  buttonLabelPlay: 'Play',
+  showButtonLabel: true,
   buttonSize: BUTTON_SIZES.LARGE,
   buttonIconPlay: ICON_IDS.PLAY_SOLID,
   buttonIconPause: ICON_IDS.PAUSE,
@@ -145,7 +157,8 @@ DefaultPoster.args = {
   video: 'https://s7d1.scene7.com/is/content/kyndryl/5.%20MS-Launch-Social-1080.captions',
   title: 'Video Title',
   poster: 'https://s7d1.scene7.com/is/image/kyndryl/NicolasSekkaki_AppsDataAI_16x9?qlt=85&wid=600&ts=1649881438992&dpr=off',
-  buttonLabel: 'Play',
+  buttonLabelPlay: 'Play',
+  showButtonLabel: true,
   buttonSize: BUTTON_SIZES.LARGE,
   buttonIconPlay: ICON_IDS.PLAY_SOLID,
   buttonIconPause: ICON_IDS.PAUSE,
@@ -166,6 +179,9 @@ export const VideoBackground = Template.bind({});
 VideoBackground.args = {
   video: 'https://s7d1.scene7.com/is/content/kyndryl/5.%20MS-Launch-Social-1080.captions',
   title: 'Video Title',
+  buttonLabelPlay: 'Play video',
+  buttonLabelPause: 'Pause video',
+  showButtonLabel: false,
   buttonSize: BUTTON_SIZES.SMALL,
   buttonIconPlay: ICON_IDS.PLAY_SOLID,
   buttonIconPause: ICON_IDS.PAUSE,

--- a/src/components/videoPlayer/videoPlayer.ts
+++ b/src/components/videoPlayer/videoPlayer.ts
@@ -172,7 +172,7 @@ export class VideoPlayer extends LitElement {
               size=${this.buttonSize}
               icon=${this.buttonIconPlay}
               iconPosition=${this.buttonIconPosition}
-              iconAriaLabel=${this._showButtonLabel ? null : this._buttonLabel}
+              ariaLabel=${this._showButtonLabel ? null : this._buttonLabel}
               @click="${e => this._onTriggerClick(e)}"
             >
               <span class="${PREFIX_CLASS}-video-player--cta-label">
@@ -205,7 +205,7 @@ export class VideoPlayer extends LitElement {
             size=${this.buttonSize}
             icon=${this._isPlaying ? this.buttonIconPause : this.buttonIconPlay}
             iconPosition=${this.buttonIconPosition}
-            iconAriaLabel=${this._showButtonLabel ? null : this._buttonLabel}
+            ariaLabel=${this._showButtonLabel ? null : this._buttonLabel}
             @click="${e => this._onTriggerClick(e)}"
           >
             <span class="${PREFIX_CLASS}-video-player--cta-label">${this._showButtonLabel ? html`${this._buttonLabel}` : null}</span>

--- a/src/components/videoPlayer/videoPlayer.ts
+++ b/src/components/videoPlayer/videoPlayer.ts
@@ -172,7 +172,7 @@ export class VideoPlayer extends LitElement {
               size=${this.buttonSize}
               icon=${this.buttonIconPlay}
               iconPosition=${this.buttonIconPosition}
-              ariaLabel=${this._showButtonLabel ? null : this._buttonLabel}
+              description=${this._showButtonLabel ? null : this._buttonLabel}
               @click="${e => this._onTriggerClick(e)}"
             >
               <span class="${PREFIX_CLASS}-video-player--cta-label">
@@ -205,7 +205,7 @@ export class VideoPlayer extends LitElement {
             size=${this.buttonSize}
             icon=${this._isPlaying ? this.buttonIconPause : this.buttonIconPlay}
             iconPosition=${this.buttonIconPosition}
-            ariaLabel=${this._showButtonLabel ? null : this._buttonLabel}
+            description=${this._showButtonLabel ? null : this._buttonLabel}
             @click="${e => this._onTriggerClick(e)}"
           >
             <span class="${PREFIX_CLASS}-video-player--cta-label">${this._showButtonLabel ? html`${this._buttonLabel}` : null}</span>

--- a/src/components/videoPlayer/videoPlayer.ts
+++ b/src/components/videoPlayer/videoPlayer.ts
@@ -17,7 +17,9 @@ export class VideoPlayer extends LitElement {
   @property({ type: String }) youtubeId;
   @property({ type: String }) title;
   @property({ type: String }) poster;
-  @property({ type: String }) buttonLabel;
+  @property({ type: String }) buttonLabelPlay;
+  @property({ type: String }) buttonLabelPause;
+  @property({ type: String }) showButtonLabel = 'true';
   @property() buttonSize: BUTTON_SIZES = BUTTON_SIZES.LARGE;
   @property() buttonIconPlay: ICON_IDS = ICON_IDS.PLAY_SOLID;
   @property() buttonIconPause: ICON_IDS = ICON_IDS.PAUSE;
@@ -29,9 +31,15 @@ export class VideoPlayer extends LitElement {
   private _isPlaying;
 
   @state()
-  private duration = null;
+  private _buttonLabel;
 
-  private videoPlayer;
+  @state()
+  private _showButtonLabel = true;
+
+  @state()
+  private _duration = null;
+
+  private _videoPlayer;
 
   private _classesVideoPlayer = classMap({
     [`${PREFIX_CLASS}-object-fit-cover`]: true,
@@ -45,13 +53,17 @@ export class VideoPlayer extends LitElement {
 
   protected updated(_changedProperties: PropertyValues) {
     super.updated(_changedProperties);
-    this.videoPlayer = this.renderRoot.querySelector('video');
+    this._videoPlayer = this.renderRoot.querySelector('video');
+    this._showButtonLabel = this.showButtonLabel === 'true';
+    this._buttonLabel = this._isPlaying ? this.buttonLabelPause : this.buttonLabelPlay;
     this._bindEvents();
   }
 
   connectedCallback() {
     super.connectedCallback();
     this._isPlaying = this.videoType !== VIDEO_TYPES.DEFAULT;
+    this._buttonLabel = this._isPlaying ? this.buttonLabelPause : this.buttonLabelPlay;
+    this._showButtonLabel = this.showButtonLabel === 'true';
   }
 
   disconnectedCallback() {
@@ -61,13 +73,13 @@ export class VideoPlayer extends LitElement {
 
   @eventOptions({ passive: true })
   private _bindEvents() {
-    this.videoPlayer?.addEventListener('ended', this._onVideoEnded);
-    this.videoPlayer?.addEventListener('loadedmetadata', this._onVideoMetaDataLoaded);
+    this._videoPlayer?.addEventListener('ended', this._onVideoEnded);
+    this._videoPlayer?.addEventListener('loadedmetadata', this._onVideoMetaDataLoaded);
   }
 
   @eventOptions({ passive: true })
   private _unbindEvents() {
-    this.videoPlayer?.removeEventListener('ended', this._onVideoEnded);
+    this._videoPlayer?.removeEventListener('ended', this._onVideoEnded);
   }
 
   @eventOptions({ capture: true })
@@ -88,7 +100,7 @@ export class VideoPlayer extends LitElement {
 
   private _onVideoMetaDataLoaded = () => {
     if (this.videoType === VIDEO_TYPES.DEFAULT) {
-      const durationSeconds = this.videoPlayer?.duration;
+      const durationSeconds = this._videoPlayer?.duration;
       if (durationSeconds) {
         this._setDuration(durationSeconds);
       }
@@ -112,27 +124,30 @@ export class VideoPlayer extends LitElement {
         duration = duration.slice(1);
       }
 
-      this.duration = duration;
+      this._duration = duration;
     }
   }
 
   private _playVideo() {
     this._isPlaying = true;
+    this._buttonLabel = this.buttonLabelPause;
     if (this.videoType === VIDEO_TYPES.DEFAULT) {
-      this.videoPlayer?.setAttribute('controls', 'true');
+      this._videoPlayer?.setAttribute('controls', 'true');
     }
-    this.videoPlayer?.play();
+    this._videoPlayer?.play();
   }
 
   private _pauseVideo() {
     this._isPlaying = false;
-    this.videoPlayer?.pause();
+    this._buttonLabel = this.buttonLabelPlay;
+    this._videoPlayer?.pause();
   }
 
   private _resetVideo() {
     this._isPlaying = false;
-    this.videoPlayer?.removeAttribute('controls');
-    this.videoPlayer?.load();
+    this._buttonLabel = this.buttonLabelPlay;
+    this._videoPlayer?.removeAttribute('controls');
+    this._videoPlayer?.load();
   }
 
   protected _renderYoutubePlayer(): TemplateResult | string | void {
@@ -157,11 +172,12 @@ export class VideoPlayer extends LitElement {
               size=${this.buttonSize}
               icon=${this.buttonIconPlay}
               iconPosition=${this.buttonIconPosition}
+              iconAriaLabel=${this._showButtonLabel ? null : this._buttonLabel}
               @click="${e => this._onTriggerClick(e)}"
             >
               <span class="${PREFIX_CLASS}-video-player--cta-label">
-                ${this.buttonLabel}
-                ${this.duration ? html`<span class="${PREFIX_CLASS}-video-player--cta-duration">(${this.duration})</span>` : null}
+                ${this._showButtonLabel ? html`${this._buttonLabel}` : null}
+                ${this._duration ? html`<span class="${PREFIX_CLASS}-video-player--cta-duration">(${this._duration})</span>` : null}
               </span>
             </kd-button>
           </div>
@@ -189,9 +205,10 @@ export class VideoPlayer extends LitElement {
             size=${this.buttonSize}
             icon=${this._isPlaying ? this.buttonIconPause : this.buttonIconPlay}
             iconPosition=${this.buttonIconPosition}
+            iconAriaLabel=${this._showButtonLabel ? null : this._buttonLabel}
             @click="${e => this._onTriggerClick(e)}"
           >
-            <span class="${PREFIX_CLASS}-video-player--cta-label">${this.buttonLabel}</span>
+            <span class="${PREFIX_CLASS}-video-player--cta-label">${this._showButtonLabel ? html`${this._buttonLabel}` : null}</span>
           </kd-button>
         </div>
       </div>

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -38,8 +38,8 @@
   --kd-color-h6: var(--kd-color-token-inverse);
 
   --kd-color-link: var(--kd-color-token-inverse);
-  --kd-color-link-hover: var(--kd-color-theme-primary-interactive);
-  --kd-color-link-active: var(--kd-color-theme-primary-interactive);
+  --kd-color-link-hover: var(--kd-color-token-interactive);
+  --kd-color-link-active: var(--kd-color-token-interactive);
 
   // Component specific
   --kd-color-button-primary-text: var(--kd-color-token-inverse);


### PR DESCRIPTION
Accessibility updates to the icon component to add aria-label and role.

This provides more context to the icon itself while also preventing accessibility errors for icon only buttons having no content. 

Fallback value is set to the icon name so it will always provide some context.