### PR TITLE
Removed the News and Insights from Header Shell

### DIFF
--- a/src/components/header/__stories__/header.stories.ts
+++ b/src/components/header/__stories__/header.stories.ts
@@ -31,8 +31,7 @@ const Template = args => {
           <kd-nav-item hasHoverEffect slot="trigger" hasIcon>About Us</kd-nav-item>
           <div slot="content">About Us Mega menu</div>
         </kd-mega-menu>
-
-        <kd-nav-item hasHoverEffect slot="primary-navigation">News and Insights</kd-nav-item>
+        
         <kd-nav-item hasHoverEffect slot="primary-navigation">Customer Stories</kd-nav-item>
         <kd-nav-item hasHoverEffect slot="primary-navigation">Careers</kd-nav-item>
 

--- a/src/components/header/kyndrylHeader.ts
+++ b/src/components/header/kyndrylHeader.ts
@@ -158,6 +158,9 @@ export class kyndrylHeader extends LitElement {
 
                 <a href="https://www.kyndryl.com/us/en/about-us/contact-us">
                 <span class="hover-underline-animation">Contact Us</span></a>
+
+                <a href="https://www.kyndryl.com/us/en/about-us/news">
+                <span class="hover-underline-animation">News</span></a>
             </div>
 
             <div class="${PREFIX_CLASS}-header__submenu-items-list group2">
@@ -172,6 +175,8 @@ export class kyndrylHeader extends LitElement {
 
               <a href="https://investors.kyndryl.com/overview/default.aspx">
               <span class="hover-underline-animation">Investors &#x2197;</span></a>
+
+            
             </div>
 
             <a href="https://www.kyndryl.com/us/en/about-us/corporate-responsibility/environmental-sustainability" class="${PREFIX_CLASS}-header__extra-details">
@@ -185,9 +190,7 @@ export class kyndrylHeader extends LitElement {
           </div>
         </kd-mega-menu>
  
-        <kd-nav-item hasHoverEffect slot="primary-navigation">
-        <a class ="link_text" href="https://www.kyndryl.com/us/en/news">
-        News and Insights</a></kd-nav-item>
+       
         <kd-nav-item hasHoverEffect slot="primary-navigation">
         <a class ="link_text" href="https://www.kyndryl.com/us/en/customer-stories">
         Customer Stories</a></kd-nav-item>


### PR DESCRIPTION
The News and Insights section is no longer present on our kyndryl.com primary nav.